### PR TITLE
Java Packager: support the .be (Belgium) top-level domain

### DIFF
--- a/syft/pkg/cataloger/common/cpe/java.go
+++ b/syft/pkg/cataloger/common/cpe/java.go
@@ -17,6 +17,7 @@ var (
 		"org",
 		"net",
 		"io",
+		"be",
 	}
 
 	primaryJavaManifestGroupIDFields = []string{


### PR DESCRIPTION
We have a number of packages which don't have a pom included in them, but where it can be determined from the MANIFEST logic. However, the groupId in this case starts from the top-level domain "be".

Therefore, proposal to extend the list of domains with the "be" domain.

Or maybe some more extensive list with local top-level domains?